### PR TITLE
Rename project to just "friendo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# friendo-dev
-A devkit for Friendo (a virtual pal).
+# Friendo
 
 Friendo is my attempt to make a web-based virtual pal out of simple JavaScript, that can be run purely client-side or locally in a browser. This devkit is my playground for implementation of core features before I create the actual game. Stay tuned (I say almost a year and a half after beginning this project)!

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "friendo-dev",
+  "name": "friendo",
   "version": "0.1.21",
-  "description": "Dev-kit for Friendo.",
+  "description": "Friendo: a virtual pal.",
   "main": "index.js",
-  "repository": "https://github.com/mattdelsordo/friendo-dev.git",
+  "repository": "https://github.com/mattdelsordo/friendo.git",
   "author": "Matt DelSordo",
   "license": "MIT",
   "private": false,

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -9,7 +9,7 @@ if [[ $(git log -1 --pretty=%B) != ":rocket:" ]]; then
     git commit -m ":rocket:"
 
     # push to repository
-    PUSH_URI="https://${GITHUB_TOKEN}@github.com/mattdelsordo/friendo-dev.git"
+    PUSH_URI="https://${GITHUB_TOKEN}@github.com/mattdelsordo/friendo.git"
     echo "Pushing to master"
     git push "${PUSH_URI}" >/dev/null 2>&1 # don't print secrets
 fi


### PR DESCRIPTION
## Overview
The git repo has already been renamed to friendo - this PR removes all instances of the old name in the project.

Resolves #59 (mostly)