### PR TITLE
Add loading screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friendo",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Friendo: a virtual pal.",
   "main": "index.js",
   "repository": "https://github.com/mattdelsordo/friendo.git",

--- a/src/controller/char-creator-listeners.js
+++ b/src/controller/char-creator-listeners.js
@@ -17,11 +17,13 @@ const createFriendo = () => {
 }
 
 export const showCreator = () => {
+  $('#loading, .loader').css('display', 'none')
   $('#char-creator').css('display', 'block')
   $('#main-display').css('display', 'none')
 }
 
 export const hideCreator = () => {
+  $('#loading, .loader').css('display', 'none')
   $('#char-creator').css('display', 'none')
   $('#main-display').css('display', 'block')
 }

--- a/src/controller/index.js
+++ b/src/controller/index.js
@@ -5,7 +5,7 @@ import { TICKRATE } from '../game/game-config'
 import Friendo from '../friendo/friendo'
 
 import footer from './footer'
-import creatorSetup, { showCreator } from './char-creator-listeners'
+import creatorSetup, { showCreator, hideCreator } from './char-creator-listeners'
 import { initialize, performAction } from './ui-update'
 import mainSetup from './main-listeners'
 
@@ -61,5 +61,6 @@ $(document)
       // else, initialize game
       friendo = new Friendo(savegame)
       start(friendo)
+      hideCreator()
     }
   })

--- a/ui/pages/index.pug
+++ b/ui/pages/index.pug
@@ -9,6 +9,7 @@ html(lang='en')
         script(src='bundle.js')
     body
         .container.mt-5
+            include ./loading
             include ./char-create
             include ./main
         include ../components/footer

--- a/ui/pages/loading.pug
+++ b/ui/pages/loading.pug
@@ -1,0 +1,2 @@
+.d-flex.justify-content-center#loading
+    .loader.mt-5

--- a/ui/resources/styles.css
+++ b/ui/resources/styles.css
@@ -42,12 +42,22 @@
 }
 
 /* Displays that are invisible by default */
-#egg-display{
+#egg-display, #char-creator, #main-display {
     display: none;
 }
 
-#char-creator {
-    display: none;
+@keyframes loader {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.loader {
+    border: 16px solid #f3f3f3;
+    border-top: 16px solid var(--primary);
+    border-radius: 50%;
+    width: 120px;
+    height: 120px;
+    animation: loader 2s linear infinite;
 }
 
 #leg-bar {


### PR DESCRIPTION
## Overview

Adds a loading screen for the .004s it takes to load in the UI. Not the most necessary but it looks better than before, avoiding some really noticeable visual blips.

Resolves #95 