### PR TITLE
Handle version number updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# If this is a PR to master, remember to update the version!
+
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+Connects #XXX
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "copy-res": "cp -r ui/resources/. docs/",
     "prod-js": "webpack -p",
     "dev-server": "yarn copy-res & webpack-dev-server & pug -P ui/pages/ -o docs/ -w",
-    "test": "eslint src"
+    "test": "./scripts/test-vernum.sh && eslint src"
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # check to see if the last build was a build commit, don't build if so
-if [[ $(git log -1 --pretty=%B) != ":rocket:" ]]; then
+if [[ $(git log --oneline -n1) != *":rocket:"* ]]; then
     # build webpage
     git checkout master
     yarn build-prod

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -6,10 +6,15 @@ if [[ $(git log --oneline -n1) != *":rocket:"* ]]; then
     git checkout master
     yarn build-prod
     git add -A
-    git commit -m ":rocket:"
+
+    TAG=$(egrep '"version": "([0-9]+\.[0-9]+\.[0-9]+"),' package.json | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')
+
+    git commit -m ":rocket: v$TAG"
+    git tag -a "v$TAG" -m "v$TAG"
 
     # push to repository
     PUSH_URI="https://${GITHUB_TOKEN}@github.com/mattdelsordo/friendo.git"
     echo "Pushing to master"
     git push "${PUSH_URI}" >/dev/null 2>&1 # don't print secrets
+    git push "${PUSH_URI}" --tags  >/dev/null 2>&1
 fi

--- a/scripts/test-vernum.sh
+++ b/scripts/test-vernum.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+#only perform check if in the develop branch
+if [[ $(git branch | grep \* | cut -d ' ' -f2) == "develop" ]]; then
+    # If the package.json version matches the git tag, fail
+    GIT_VER=$(git describe --abbrev=0 | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')
+    JSON_VER=$(egrep '"version": "([0-9]+\.[0-9]+\.[0-9]+"),' package.json | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')
+
+    if [[ "$GIT_VER" == "$JSON_VER" ]]; then
+        echo "ERROR: You forgot to update the version number in package.json!";
+        exit 1;
+    fi
+fi


### PR DESCRIPTION
## Overview

This PR works to manage updating the version number by: 
1. Failing tests on PRs from `develop` where the version number hasn't been updated.
2. Tag Travis's `master` commits with the version number in `package.json`.

Resolves #57 