### PR TITLE
Fix prod build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friendo",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Friendo: a virtual pal.",
   "main": "index.js",
   "repository": "https://github.com/mattdelsordo/friendo.git",

--- a/scripts/test-vernum.sh
+++ b/scripts/test-vernum.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-#only perform check if in the develop branch
-if [[ $TRAVIS_BRANCH == "master" ]]; then
+# only perform check if build is
+# 1. a travis build
+# 2. a pull request build
+# 3. merging into master
+if [[ $TRAVIS_PULL_REQUEST_SLUG != "" && $TRAVIS_BRANCH == "master" ]]; then
     # If the package.json version matches the git tag, fail
     GIT_VER=$(git describe --abbrev=0 | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')
     JSON_VER=$(egrep '"version": "([0-9]+\.[0-9]+\.[0-9]+"),' package.json | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')


### PR DESCRIPTION
## Overview

Production builds currently fail due to running the version number check on push builds in addition to PR builds, and this PR rectifies that.

Resolves #57 (more)