### PR TITLE
Revert .gitignore change to fix merge conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ yarn-error.log*
 **/.idea/tasks.xml
 
 docs/
-
-CHANGELOG.md


### PR DESCRIPTION
## Overview

Reverts a change to .gitignore to resolve develop-master merge conflict.