### PR TITLE
In deploy script, only commmit docs/

### DIFF
--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -5,7 +5,7 @@ if [[ $(git log --oneline -n1) != *":rocket:"* ]]; then
     # build webpage
     git checkout master
     yarn build-prod
-    git add -A
+    git add docs/
 
     TAG=$(egrep '"version": "([0-9]+\.[0-9]+\.[0-9]+"),' package.json | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')
 


### PR DESCRIPTION
## Overview

Resolves issues borne from doing a `git commit -A` in `scripts/deploy-gh-pages.sh`. Note to self: that was dumb.

Resolves #156 