### PR TITLE
Replace energy with fatigue

### DIFF
--- a/src/friendo/actions.js
+++ b/src/friendo/actions.js
@@ -65,7 +65,7 @@ export const exercise = (friendo, action, reps = 0, everyRep, end) => {
     console.log(`Rep: ${reps}`)
     // add or subtract energy
     const cost = REP_COST[action] * friendo.zodiac.getStatBonus(action)
-    friendo.modifyEnergy(cost, action === ACTIONS.FEED)
+    friendo.modifyFatigue(cost, action === ACTIONS.FEED)
     // add exp if applicable
     // have to parse out the action id to get the state id
     friendo.addExp(stat, REP_REWARD[action])
@@ -75,14 +75,14 @@ export const exercise = (friendo, action, reps = 0, everyRep, end) => {
     everyRep(friendo)
 
     // check if energy has dipped below zero, if so, sleep
-    if (friendo.getEnergyLeft() <= 0) {
+    if (friendo.getEnergyPercent() <= 0) {
       console.log('Next rep! (exhausted)')
       friendo.state = loadState(this, sleepID)
       return exercise(friendo, ACTIONS.SLEEP, -1, everyRep, end)
     }
 
     // if sleeping, check if energy >= max, if so, return to idle
-    if (action === ACTIONS.SLEEP && friendo.getEnergyLeft() >= 1.0) {
+    if (action === ACTIONS.SLEEP && friendo.getEnergyPercent() >= 1.0) {
       console.log('Done (sleeping && energy = max)')
       return end()
     }

--- a/src/friendo/default.js
+++ b/src/friendo/default.js
@@ -13,7 +13,7 @@ export const DEFAULT_OWNER = 'Mrot'
 
 export const DEFAULT_LEVEL = 0
 export const DEFAULT_MAX_ENERGY = 100
-export const DEFAULT_ENERGY = DEFAULT_MAX_ENERGY
+export const DEFAULT_FATIGUE = 0
 
 export const DEFAULT_STATS = {
   [STATS.CORE]: 0,

--- a/src/friendo/friendo.js
+++ b/src/friendo/friendo.js
@@ -32,7 +32,7 @@ import {
   DEFAULT_STATE,
   DEFAULT_STAT_STAGES,
   DEFAULT_LEVEL,
-  DEFAULT_ENERGY,
+  DEFAULT_FATIGUE,
   DEFAULT_MAX_ENERGY,
   DEFAULT_EXP,
   DEFAULT_ZODIAC,
@@ -57,7 +57,7 @@ export default class Friendo {
     this.owner = fromJSON.owner || DEFAULT_OWNER
     this.element = fromJSON.element ? selectElement(fromJSON.element) : DEFAULT_ELEMENT
     this.zodiac = fromJSON.zodiac ? getZodiac(fromJSON.zodiac) : DEFAULT_ZODIAC
-    this.energy = fromJSON.energy || DEFAULT_ENERGY
+    this.fatigue = fromJSON.fatigue || DEFAULT_FATIGUE
     this.exp = fromJSON.exp || DEFAULT_EXP
 
     // set default derived values
@@ -80,7 +80,7 @@ export default class Friendo {
       stats: this._stats,
       state: this.state,
       zodiac: this.zodiac,
-      energy: this.energy,
+      fatigue: this.fatigue,
       exp: this.exp,
     }
   }
@@ -181,8 +181,8 @@ export default class Friendo {
   }
 
   // returns percentage of energy the friendo currently has
-  getEnergyLeft() {
-    return this.energy / this.maxEnergy
+  getEnergyPercent() {
+    return (this.maxEnergy - this.fatigue) / this.maxEnergy
   }
 
   // exp multiplier based off taste level
@@ -192,14 +192,14 @@ export default class Friendo {
 
   /**
    * Adds energy to the friendo's reserve
-   * @param amnt - amount of energy to add
+   * @param amnt - amount of fatigue to remove
    * @param feed - whether or not to factor in taste multiplier
    */
-  modifyEnergy(amnt, feed = false) {
+  modifyFatigue(amnt, feed = false) {
     const newAmnt = feed ? (amnt * this.getFoodMultiplier()) : amnt
-    if (newAmnt + this.energy >= this.maxEnergy) this.energy = this.maxEnergy
-    else if (this.energy + newAmnt <= 0) this.energy = 0
-    else this.energy = this.energy + newAmnt
+    if (this.fatigue - newAmnt >= this.maxEnergy) this.fatigue = this.maxEnergy
+    else if (this.fatigue - newAmnt <= 0) this.fatigue = 0
+    else this.fatigue = this.fatigue - newAmnt
   }
 
   // exp multiplier based off meme tolerance

--- a/src/game/setup/ui-update.js
+++ b/src/game/setup/ui-update.js
@@ -161,7 +161,7 @@ export const initialize = (friendo) => {
   setLevel(friendo.level)
   setZodiac(friendo.zodiac, friendo.element.strokeStyle)
   setAllStats(friendo)
-  setEnergy(friendo.getEnergyLeft())
+  setEnergy(friendo.getEnergyPercent())
 
   // show stats based on level
   // CORE=0 means we're still in the tutorial
@@ -241,7 +241,7 @@ export const performAction = (friendo, action, reps = 1) => {
       // save
       save(JSON.stringify(f))
       // update energy bar
-      setEnergy(f.getEnergyLeft())
+      setEnergy(f.getEnergyPercent())
       // check to see if any stat can be made visible
       updateStatVisibility(f)
 


### PR DESCRIPTION
## Overview

If we represent energy as "energy lost" instead of "energy gained", Friendos will gain free energy when `maxEnergy` is increased. This PR makes that change to avoid potential future bugs.

Resolves #109
