### PR TITLE
Remove animations from the state class

### DIFF
--- a/src/friendo/animation/curl.js
+++ b/src/friendo/animation/curl.js
@@ -1,0 +1,55 @@
+import FAnimation from './f-animation'
+import dumbbell from '../art/props/dumbbell'
+import { left, right } from '../art/art-util'
+
+export default class ACurl extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+    ]
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    this.subframe(g, x, y, friendo, blink, words, 0.45, 0.05)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    this.subframe(g, x, y, friendo, blink, words)
+  }
+
+  subframe(g, x, y, friendo, blink, words, armAngle = 0.2, squat = 0) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * squat)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+
+    const dumbbellBrush = (_g) => {
+      dumbbell(
+        _g,
+        friendo.element.handCoord.x,
+        friendo.element.handCoord.y,
+        friendo.element.armGirth,
+      )
+    }
+    left(g, x - armOffset.x, y - armOffset.y, dumbbellBrush, armAngle) // left dumbbell
+    right(g, x + armOffset.x, y - armOffset.y, dumbbellBrush, armAngle) // right dumbbell
+
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+  }
+}

--- a/src/friendo/animation/dog-cuddle.js
+++ b/src/friendo/animation/dog-cuddle.js
@@ -1,0 +1,95 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+import { STATS } from '../constants'
+import { Dog } from '../art/props/dog'
+
+const DOG_COORDS = [
+  { x: 32, y: 0 },
+  { x: -33, y: 0 },
+  { x: 21, y: -60 },
+  { x: -32, y: -100 },
+  { x: 34, y: -146 },
+]
+
+export default class ACuddle extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+
+    this.dogs = [new Dog(), new Dog(), new Dog(), new Dog(), new Dog()]
+
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+    ]
+  }
+
+  coreToDogs(coreLevel) {
+    if (coreLevel > 4) return 5
+    else if (coreLevel > 3) return 4
+    else if (coreLevel > 2) return 3
+    else if (coreLevel > 1) return 2
+    return 1
+  }
+
+  // Draw dogs based on predefined coordinates
+  drawDogs(g, x, y, friendo, lick) {
+    for (let i = 0; i < this.coreToDogs(friendo.getStatStage(STATS.CORE)); i += 1) {
+      this.dogs[i].paint(g, x + DOG_COORDS[i].x, y + DOG_COORDS[i].y, lick)
+    }
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    this.subframe1(g, x, y, friendo, blink, words)
+    this.drawDogs(g, x, y, friendo, true)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    this.subframe2(g, x, y, friendo, blink, words)
+    this.drawDogs(g, x, y, friendo, true)
+  }
+
+  subframe1(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap, bodyOffset } = friendo.element
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.25 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+
+  subframe2(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.30 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+}

--- a/src/friendo/animation/egg.js
+++ b/src/friendo/animation/egg.js
@@ -1,0 +1,42 @@
+import FAnimation from './f-animation'
+import { STATS } from '../constants'
+
+/**
+ * Idle egg state
+ */
+
+export default class AEgg extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+    this.shaking = (old) ? old.shaking : false
+  }
+
+  // Egg animation has a unique draw method; it doesnt behave regularly
+  draw(g, x, y, friendo) {
+    this.predraw(g, x, y, friendo)
+
+    // Shake if not currently shaking and with a probability
+    // based on egg level
+    const rand = Math.floor(Math.random() * 100)
+    const shake =
+      (friendo.getStat(STATS.EGG) < 2 ? 0 : ((friendo.getStat(STATS.EGG) - 1) * 10 >= rand))
+    if (!this.shaking && shake) {
+      this.shaking = true
+    }
+
+    // do a shake
+    if (this.shaking) {
+      this.shaking = false
+      return this.frame2(g, x, y, friendo)
+    }
+    return this.frame1(g, x, y, friendo)
+  }
+
+  frame1(g, x, y, friendo) {
+    friendo.element.drawEgg(g, x, y, friendo)
+  }
+
+  frame2(g, x, y, friendo) {
+    friendo.element.drawEgg(g, x + 2, y, friendo)
+  }
+}

--- a/src/friendo/animation/f-animation.js
+++ b/src/friendo/animation/f-animation.js
@@ -1,0 +1,104 @@
+import {
+  BLINK_CHANCE,
+  BLINK_TIME,
+  SPEAK_CHANCE,
+  SPEAK_TIME,
+  TOTAL_EVENT_CHANCE,
+} from '../constants'
+import { left, right } from '../art/art-util'
+
+/**
+ * Class to handle default Friendo-Animation behavior
+ * Do not use as an animation itself
+ * "FAnimation" because "Animation" is a pre-existing class
+ */
+
+const FRAME_DELAY = 2
+
+export default class FAnimation {
+  constructor(old, phrasebook) {
+    // carry over components of previous animation for continuity
+    if (!old) old = {}
+    this.blinkRate = old.blinkRate || BLINK_CHANCE
+    this.speakRate = old.speakRate || SPEAK_CHANCE
+    this.blink = old.blink || 0
+    this.speak = old.speak || 0
+    this.frame = old.frame || 0
+    this.tickCounter = old.frame || 0
+    this.words = old.words || ''
+
+    // define animation-specific parameters
+    this.phrasebook = phrasebook
+    this.frameDelay = FRAME_DELAY
+
+    this.frames = [this.frame1]
+  }
+
+  toJSON() {
+    return {
+      blinkRate: this.blinkRate,
+      speakRate: this.speakRate,
+      words: this.words,
+    }
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap, bodyOffset } = friendo.element
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.25 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+  }
+
+  pickPhrase(friendo) {
+    const list = this.phrasebook(friendo)
+    const selected = Math.floor(Math.random() * list.length)
+    return list[selected]
+  }
+
+  draw(g, x, y, friendo) {
+    /**
+     *  I know this is terrible practice but sorry yes my draw method has side effects
+     */
+    // handle blink
+    if (this.blink > 0) {
+      this.blink -= 1
+    } else if (Math.random() * TOTAL_EVENT_CHANCE < this.blinkRate) {
+      // not blinking, chance to blink
+      this.blink = BLINK_TIME
+    }
+
+    // handle speech
+    if (this.speak > 0) {
+      // decrement speech timer if greater than 0
+      this.speak -= 1
+    } else if (Math.random() * TOTAL_EVENT_CHANCE < this.speakRate) {
+      // chance to reset speech timer and pick a new phrase
+      this.speak = SPEAK_TIME
+      this.words = this.pickPhrase(friendo)
+    } else {
+      // if speak <= 0, don't speak
+      this.words = ''
+    }
+
+    friendo.element.setColors(g)
+
+    // only update the frame if the delay has elapsed
+    this.tickCounter = (this.tickCounter + 1) % this.frameDelay
+    if (this.tickCounter === 0) this.frame = (this.frame + 1) % this.frames.length
+    return this.frames[this.frame](g, x, y, friendo, this.blink, this.words)
+  }
+}

--- a/src/friendo/animation/f-animation.js
+++ b/src/friendo/animation/f-animation.js
@@ -69,7 +69,8 @@ export default class FAnimation {
     return list[selected]
   }
 
-  draw(g, x, y, friendo) {
+  // prerequisite setup for the draw method
+  predraw(g, x, y, friendo) {
     /**
      *  I know this is terrible practice but sorry yes my draw method has side effects
      */
@@ -95,6 +96,10 @@ export default class FAnimation {
     }
 
     friendo.element.setColors(g)
+  }
+
+  draw(g, x, y, friendo) {
+    this.predraw(g, x, y, friendo)
 
     // only update the frame if the delay has elapsed
     this.tickCounter = (this.tickCounter + 1) % this.frameDelay

--- a/src/friendo/animation/feed.js
+++ b/src/friendo/animation/feed.js
@@ -1,0 +1,110 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+import { drawGenericFood } from '../art/props/food'
+
+export default class AFeed extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+    this.frameDelay = 1
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+      this.frame3.bind(this),
+      this.frame4.bind(this),
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+      this.frame3.bind(this),
+      this.frame4.bind(this),
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+      this.frame5.bind(this),
+      this.frame5.bind(this),
+      this.frame5.bind(this),
+      this.frame5.bind(this),
+    ]
+  }
+
+  subframe1(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap, bodyOffset } = friendo.element
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.25 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+
+  subframe2(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.30 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+
+  drawFood(g, cT, frame) {
+    drawGenericFood(g, cT.mouth.x, cT.mouth.y + 20, (10 - frame) / 10)
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    this.mouthIsOpen = true
+    this.isSmiling = false
+    const t = this.subframe1(g, x, y, friendo, blink, words)
+    this.drawFood(g, t, this.frame)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    this.mouthIsOpen = false
+    this.isSmiling = false
+    const t = this.subframe1(g, x, y, friendo, blink, words)
+    this.drawFood(g, t, this.frame)
+  }
+
+  frame3(g, x, y, friendo, blink, words) {
+    this.mouthIsOpen = true
+    this.isSmiling = false
+    const t = this.subframe2(g, x, y, friendo, blink, words)
+    this.drawFood(g, t, this.frame)
+  }
+
+  frame4(g, x, y, friendo, blink, words) {
+    this.mouthIsOpen = false
+    this.isSmiling = false
+    const t = this.subframe2(g, x, y, friendo, blink, words)
+    this.drawFood(g, t, this.frame)
+  }
+
+  frame5(g, x, y, friendo, blink, words) {
+    this.isSmiling = true
+    this.mouthIsOpen = false
+    const t = this.subframe2(g, x, y, friendo, blink, words)
+    this.drawFood(g, t, this.frame)
+  }
+}

--- a/src/friendo/animation/groom.js
+++ b/src/friendo/animation/groom.js
@@ -1,0 +1,98 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+import drawHairbrush from '../art/props/hairbrush'
+
+const rotateHairbrush = (g, x, y, angle = 0) => {
+  g.save()
+
+  g.translate(x, y)
+  g.rotate(Math.PI * angle)
+  g.translate(-x, -y)
+
+  drawHairbrush(g, x, y)
+
+  g.restore()
+}
+
+export default class AGroom extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+
+    this.isSmiling = true
+
+    this.frameDelay = 1
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+      this.frame3.bind(this),
+      this.frame4.bind(this),
+    ]
+  }
+
+  /* eslint-disable prefer-destructuring */
+  frame1(g, x, y, friendo, blink, words) {
+    const cT = this.subframe1(g, x, y, friendo, blink, words)
+    rotateHairbrush(g, x + 24 + (cT.hairXOffset || 0), cT.hairY - 4, -0.25)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    const cT = this.subframe1(g, x, y, friendo, blink, words)
+    rotateHairbrush(g, x + 22 + (cT.hairXOffset || 0), cT.hairY, -0.25)
+  }
+
+  frame3(g, x, y, friendo, blink, words) {
+    const cT = this.subframe2(g, x, y, friendo, blink, words)
+    rotateHairbrush(g, x + 26 + (cT.hairXOffset || 0), cT.hairY + 4, -0.25)
+  }
+
+  frame4(g, x, y, friendo, blink, words) {
+    const cT = this.subframe2(g, x, y, friendo, blink, words)
+    rotateHairbrush(g, x + 28 + (cT.hairXOffset || 0), cT.hairY + 6, -0.25)
+  }
+  /* eslint-enable prefer-destructuring */
+
+  subframe1(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap, bodyOffset } = friendo.element
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.25 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+
+  subframe2(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.30 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+}

--- a/src/friendo/animation/idle.js
+++ b/src/friendo/animation/idle.js
@@ -1,0 +1,36 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+
+/**
+ * Handles idle animation
+ */
+
+export default class AIdle extends FAnimation {
+  constructor(old, phrasebook) {
+    super(old, phrasebook)
+
+    this.frames = [this.frame1, this.frame2]
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.30 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+  }
+}

--- a/src/friendo/animation/incubate.js
+++ b/src/friendo/animation/incubate.js
@@ -1,0 +1,10 @@
+import AEgg from './egg'
+import lamp from '../art/props/lamp'
+
+export default class AIncubate extends AEgg {
+  draw(g, x, y, friendo) {
+    super.draw(g, x, y, friendo)
+
+    lamp(g, x, y)
+  }
+}

--- a/src/friendo/animation/munch.js
+++ b/src/friendo/animation/munch.js
@@ -1,0 +1,99 @@
+import FAnimation from './f-animation'
+import { drawGenericFood } from '../art/props/food'
+import { left, right } from '../art/art-util'
+
+export default class AMunch extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+
+    this.frame = 0
+    this.frameDelay = 1
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+      this.frame3.bind(this),
+      this.frame4.bind(this),
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+      this.frame3.bind(this),
+      this.frame4.bind(this),
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+      this.frame3.bind(this),
+      this.frame4.bind(this),
+    ]
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    this.mouthIsOpen = false
+    const cT = this.subframe1(g, x, y, friendo, blink, words)
+    this.drawFood(g, cT, this.frame)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    this.mouthIsOpen = true
+    const cT = this.subframe1(g, x, y, friendo, blink, words)
+    this.drawFood(g, cT, this.frame)
+  }
+
+  frame3(g, x, y, friendo, blink, words) {
+    this.mouthIsOpen = false
+    const cT = this.subframe2(g, x, y, friendo, blink, words)
+    this.drawFood(g, cT, this.frame)
+  }
+
+  frame4(g, x, y, friendo, blink, words) {
+    this.mouthIsOpen = true
+    const cT = this.subframe2(g, x, y, friendo, blink, words)
+    this.drawFood(g, cT, this.frame)
+  }
+
+  drawFood(g, cT, frame) {
+    drawGenericFood(g, cT.mouth.x, cT.mouth.y + 20, (10 - frame) / 10)
+  }
+
+  subframe1(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap, bodyOffset } = friendo.element
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.25 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+
+  subframe2(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.1)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.30 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+}

--- a/src/friendo/animation/pet.js
+++ b/src/friendo/animation/pet.js
@@ -1,0 +1,108 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+import { drawHandDown as paintHand } from '../art/props/hand'
+
+const FRAME_DELAY = 1
+
+export default class APet extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+
+    this.isSmiling = true
+    this.frameDelay = FRAME_DELAY
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+      this.frame3.bind(this),
+      this.frame4.bind(this),
+    ]
+  }
+
+  subframeA(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap, bodyOffset } = friendo.element
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.25 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(
+      g,
+      x,
+      y - bodyOffset,
+      friendo,
+      blink,
+      true,
+    )
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+
+  subframeB(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.30 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(
+      g,
+      x,
+      y - bodyOffset,
+      friendo,
+      blink,
+      true,
+    )
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+    return computedTethers
+  }
+
+  handUp(g, x, y) {
+    paintHand(g, x - 4, y - 3)
+  }
+
+  handDown(g, x, y) {
+    paintHand(g, x - 4, y + 1)
+  }
+
+  // !!!!! this is not defined when the functions get called in context
+  frame1(g, x, y, friendo, blink, words) {
+    const t = this.subframeA(g, x, y, friendo, blink, words)
+    this.handUp(g, x, t.hairY)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    const t = this.subframeA(g, x, y, friendo, blink, words)
+    this.handDown(g, x, t.hairY)
+  }
+
+  frame3(g, x, y, friendo, blink, words) {
+    const t = this.subframeB(g, x, y, friendo, blink, words)
+    this.handUp(g, x, t.hairY)
+  }
+
+  frame4(g, x, y, friendo, blink, words) {
+    const t = this.subframeB(g, x, y, friendo, blink, words)
+    this.handDown(g, x, t.hairY)
+  }
+}

--- a/src/friendo/animation/read.js
+++ b/src/friendo/animation/read.js
@@ -1,0 +1,51 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+import { drawOpenBook } from '../art/props/book'
+
+export default class ARead extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+
+    this.glasses = true
+
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+    ]
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    this.subframe(g, x, y, friendo, blink, words)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    this.subframe(g, x, y, friendo, blink, words, 0.40, 0.05)
+  }
+
+  subframe(g, x, y, friendo, blink, words, armAngle = 0.25, squatFactor = 0) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const squatOffset = friendo.element.bodyOffset * squatFactor
+    const bodyOffset = friendo.element.bodyOffset - squatOffset
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y + (-armOffset.y + squatOffset), armBrush, 0.2)// right arm
+
+    left(g, x - armOffset.x, y - armOffset.y, (_g) => {
+      drawOpenBook(_g, friendo.element.handCoord.x, friendo.element.handCoord.y)
+    }, armAngle)
+
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+  }
+}

--- a/src/friendo/animation/situp.js
+++ b/src/friendo/animation/situp.js
@@ -1,0 +1,69 @@
+import FAnimation from './f-animation'
+import { down, left } from '../art/art-util'
+
+export default class ASitup extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+    ]
+  }
+
+  // compose old frames to compensate for lack of old draw method
+  frame1(g, x, y, friendo, blink, words) {
+    down(g, (_g, _x, _y) => {
+      this.subframe1(_g, _x, _y, friendo, blink, words)
+    }, x, y)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    down(g, (_g, _x, _y) => {
+      this.subframe2(_g, _x, _y, friendo, blink, words)
+    }, x, y)
+  }
+
+  subframe1(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap, bodyOffset } = friendo.element
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset - bodyOffset,
+    }
+    const armAngle = 0.15 // pi radians
+
+    left(g, x - thighGap, y + bodyOffset, legBrush) // left leg
+    left(g, x + thighGap, y + bodyOffset, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+
+    const computedTethers = friendo.element.drawCore(g, x, y, friendo, this.blink)
+    left(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    if (words) {
+      friendo.element.speak(g, (computedTethers.speech.x + 50), computedTethers.speech.y, words)
+    }
+  }
+
+  subframe2(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap, bodyOffset } = friendo.element
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset - bodyOffset,
+    }
+    const armAngle = 0.25 // pi radians
+
+    left(g, x - thighGap, y + bodyOffset, legBrush) // left leg
+    left(g, x + thighGap, y + bodyOffset, legBrush) // right leg
+    left(g, x - armOffset.x - 6, y - armOffset.y, armBrush, armAngle)// left arm
+
+    const computedTethers = friendo.element.drawCore(g, x - 6, y, friendo, this.blink)
+    left(g, x + (armOffset.x - 6), y - armOffset.y, armBrush, armAngle)// right arm
+    if (words) {
+      friendo.element.speak(g, (computedTethers.speech.x + 50), computedTethers.speech.y, words)
+    }
+  }
+}

--- a/src/friendo/animation/sleep.js
+++ b/src/friendo/animation/sleep.js
@@ -1,0 +1,32 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+
+export default class ASleep extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+
+    this.frames = [this.frame1]
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.1)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+    const armAngle = 0.15 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, true)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+  }
+}

--- a/src/friendo/animation/squat.js
+++ b/src/friendo/animation/squat.js
@@ -1,0 +1,44 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+
+export default class ASquat extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+    ]
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    this.subframe(g, x, y, friendo, blink, words, 0.3)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    this.subframe(g, x, y, friendo, blink, words)
+  }
+
+  subframe(g, x, y, friendo, blink, words, squatFactor = 0) {
+    const squatAmount = squatFactor * friendo.element.bodyOffset
+
+    // pre-compute constants for drawing for ease of readability
+    const thighGap = friendo.element.thighGap * (1 + squatFactor)
+    const bodyOffset = friendo.element.bodyOffset - squatAmount
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset - squatAmount,
+    }
+    const armAngle = 0.30 // pi radians
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+  }
+}

--- a/src/friendo/animation/surf-web.js
+++ b/src/friendo/animation/surf-web.js
@@ -1,0 +1,49 @@
+import FAnimation from './f-animation'
+import { left, right } from '../art/art-util'
+import { drawPhone, PHONE_SCREEN_OFF, PHONE_SCREEN_ON } from '../art/props/phone'
+
+export default class ASurf extends FAnimation {
+  constructor(old, phrases) {
+    super(old, phrases)
+
+    this.frames = [
+      this.frame1.bind(this),
+      this.frame2.bind(this),
+    ]
+  }
+
+  frame1(g, x, y, friendo, blink, words) {
+    this.subframe(g, x, y, friendo, blink, words, 0.20, 0, PHONE_SCREEN_OFF)
+  }
+
+  frame2(g, x, y, friendo, blink, words) {
+    this.subframe(g, x, y, friendo, blink, words, 0.30, 0.05, PHONE_SCREEN_ON)
+  }
+
+  subframe(g, x, y, friendo, blink, words, armAngle = 0.2, squat = 0, phoneScreen) {
+    // pre-compute constants for drawing for ease of readability
+    const { thighGap } = friendo.element
+    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * squat)
+    const legBrush = friendo.element.legBrush(friendo)
+    const armBrush = friendo.element.armBrush(friendo)
+    const armOffset = {
+      x: friendo.element.armOffset.xOffset,
+      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
+    }
+
+    left(g, x - thighGap, y, legBrush) // left leg
+    right(g, x + thighGap, y, legBrush) // right leg
+    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
+    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
+
+    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
+    if (words) {
+      friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, words)
+    }
+
+    const phoneBrush = (_g) => {
+      drawPhone(_g, friendo.element.handCoord.x, friendo.element.handCoord.y, phoneScreen)
+    }
+    left(g, x - armOffset.x, y - armOffset.y, phoneBrush, armAngle) // phone
+  }
+}

--- a/src/friendo/constants.js
+++ b/src/friendo/constants.js
@@ -69,7 +69,7 @@ export const STAT_STAGES = {
   [STATS.TASTE]: [1],
   [STATS.DOG]: [1, 20, 40, 65, 90],
   [STATS.MEME]: [1],
-  [STATS.EGG]: [1, 2, 3, 4],
+  [STATS.EGG]: [1, 10, 20, 30],
 }
 
 // array of stats to actually include in level calculations

--- a/src/friendo/element/element.js
+++ b/src/friendo/element/element.js
@@ -120,9 +120,9 @@ export default class Element {
     if (friendo.getStatStage(STATS.SIGHT) > 2) {
       // lvl 7 and up, 3 eyes
       // fire types are a special case
-      this.drawEye(g, x, y - 8, doBlink, friendo.state.isSmiling)
-      this.drawEye(g, x - 8, y, doBlink, friendo.state.isSmiling)
-      this.drawEye(g, x + 8, y, doBlink, friendo.state.isSmiling)
+      this.drawEye(g, x, y - 8, doBlink, friendo.state.anim.isSmiling)
+      this.drawEye(g, x - 8, y, doBlink, friendo.state.anim.isSmiling)
+      this.drawEye(g, x + 8, y, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
       // doesn't need glasses to see anymore after 9
@@ -130,14 +130,14 @@ export default class Element {
     } else if (friendo.getStatStage(STATS.SIGHT) > 1) {
       // lvl 4 and up, 2 eyes
       // eyes must be moved down if a fire element
-      this.drawEye(g, x - 8, y, doBlink, friendo.state.isSmiling)
-      this.drawEye(g, x + 8, y, doBlink, friendo.state.isSmiling)
+      this.drawEye(g, x - 8, y, doBlink, friendo.state.anim.isSmiling)
+      this.drawEye(g, x + 8, y, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
       if (friendo.state.glasses) twoLens(g, x, y)
     } else {
       // default = 1 eye
-      this.drawEye(g, x, y, doBlink, friendo.state.isSmiling)
+      this.drawEye(g, x, y, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
       if (friendo.state.glasses) oneLens(g, x, y)
@@ -162,7 +162,7 @@ export default class Element {
     const tempFill = g.fillStyle
     g.fillStyle = g.strokeStyle
 
-    if (friendo.state.mouthIsOpen) {
+    if (friendo.state.anim.mouthIsOpen) {
       g.fillRect(MOUTH_START, y, MOUTH_LENGTH, MOUTH_OPEN_HEIGHT)
     } else {
       drawLine(g, MOUTH_START, y, MOUTH_START + MOUTH_LENGTH, y)

--- a/src/friendo/element/element.js
+++ b/src/friendo/element/element.js
@@ -126,7 +126,7 @@ export default class Element {
 
       // handle glasses
       // doesn't need glasses to see anymore after 9
-      if (friendo.state.glasses && friendo.getStatStage(STATS.SIGHT) < 3) threeLens(g, x, y)
+      if (friendo.state.anim.glasses && friendo.getStatStage(STATS.SIGHT) < 4) threeLens(g, x, y)
     } else if (friendo.getStatStage(STATS.SIGHT) > 1) {
       // lvl 4 and up, 2 eyes
       // eyes must be moved down if a fire element
@@ -134,13 +134,13 @@ export default class Element {
       this.drawEye(g, x + 8, y, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
-      if (friendo.state.glasses) twoLens(g, x, y)
+      if (friendo.state.anim.glasses) twoLens(g, x, y)
     } else {
       // default = 1 eye
       this.drawEye(g, x, y, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
-      if (friendo.state.glasses) oneLens(g, x, y)
+      if (friendo.state.anim.glasses) oneLens(g, x, y)
     }
 
     drawHookMarker(g, x, y)

--- a/src/friendo/element/element.js
+++ b/src/friendo/element/element.js
@@ -384,9 +384,7 @@ export default class Element {
   }
 
   // positions speech and handles speaking when in a speaking state
-  speak(g, x, y, friendo) {
-    if (friendo.state.speak) {
-      drawSpeech(g, x, y, friendo.state.words)
-    }
+  speak(g, x, y, words) {
+    drawSpeech(g, x, y, words)
   }
 }

--- a/src/friendo/element/fire.js
+++ b/src/friendo/element/fire.js
@@ -74,9 +74,9 @@ export default class Fire extends Element {
     if (friendo.getStatStage(STATS.SIGHT) > 2) {
       // lvl 7 and up, 3 eyes
       // fire types are a special case
-      this.drawEye(g, x, y - 6, doBlink, friendo.state.isSmiling)
-      this.drawEye(g, x - 6, y + 4, doBlink, friendo.state.isSmiling)
-      this.drawEye(g, x + 6, y + 4, doBlink, friendo.state.isSmiling)
+      this.drawEye(g, x, y - 6, doBlink, friendo.state.anim.isSmiling)
+      this.drawEye(g, x - 6, y + 4, doBlink, friendo.state.anim.isSmiling)
+      this.drawEye(g, x + 6, y + 4, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
       // doesn't need glasses to see anymore after 9
@@ -84,14 +84,14 @@ export default class Fire extends Element {
     } else if (friendo.getStatStage(STATS.SIGHT) > 1) {
       // lvl 4 and up, 2 eyes
       // eyes must be moved down if a fire element
-      this.drawEye(g, x - 6, y + 4, doBlink, friendo.state.isSmiling)
-      this.drawEye(g, x + 6, y + 4, doBlink, friendo.state.isSmiling)
+      this.drawEye(g, x - 6, y + 4, doBlink, friendo.state.anim.isSmiling)
+      this.drawEye(g, x + 6, y + 4, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
       if (friendo.state.glasses) twoLens(g, x, y + 3)
     } else {
       // default = 1 eye
-      this.drawEye(g, x, y, doBlink, friendo.state.isSmiling)
+      this.drawEye(g, x, y, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
       if (friendo.state.glasses) oneLens(g, x, y)
@@ -108,7 +108,7 @@ export default class Fire extends Element {
     const tempFill = g.fillStyle
     g.fillStyle = g.strokeStyle
 
-    if (friendo.state.mouthIsOpen) {
+    if (friendo.state.anim.mouthIsOpen) {
       g.fillRect(MOUTH_START, y, MOUTH_LENGTH, MOUTH_OPEN_HEIGHT)
     } else {
       drawLine(g, MOUTH_START, y, MOUTH_START + MOUTH_LENGTH, y)

--- a/src/friendo/element/fire.js
+++ b/src/friendo/element/fire.js
@@ -80,7 +80,9 @@ export default class Fire extends Element {
 
       // handle glasses
       // doesn't need glasses to see anymore after 9
-      if (friendo.state.glasses && friendo.getStatStage(STATS.SIGHT) < 3) threeLens(g, x, y + 3)
+      if (friendo.state.anim.glasses && friendo.getStatStage(STATS.SIGHT) < 4) {
+        threeLens(g, x, y + 3)
+      }
     } else if (friendo.getStatStage(STATS.SIGHT) > 1) {
       // lvl 4 and up, 2 eyes
       // eyes must be moved down if a fire element
@@ -88,13 +90,13 @@ export default class Fire extends Element {
       this.drawEye(g, x + 6, y + 4, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
-      if (friendo.state.glasses) twoLens(g, x, y + 3)
+      if (friendo.state.anim.glasses) twoLens(g, x, y + 3)
     } else {
       // default = 1 eye
       this.drawEye(g, x, y, doBlink, friendo.state.anim.isSmiling)
 
       // handle glasses
-      if (friendo.state.glasses) oneLens(g, x, y)
+      if (friendo.state.anim.glasses) oneLens(g, x, y)
     }
 
     drawHookMarker(g, x, y)

--- a/src/friendo/state/fitness/curl.js
+++ b/src/friendo/state/fitness/curl.js
@@ -1,8 +1,7 @@
 
 import Exercise from './exercise'
-import { left, right } from '../../art/art-util'
 import { ACTIONS } from '../../constants'
-import dumbbell from '../../art/props/dumbbell'
+import ACurl from '../../animation/curl'
 
 export const ID = ACTIONS.ARM
 
@@ -10,54 +9,7 @@ export default class Curls extends Exercise {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-  }
 
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 4
-    switch (this.frame) {
-      case 2:
-      case 3:
-        this.frame1(g, x, y, friendo, 0.45, 0.05)
-        break
-      case 0:
-      case 1:
-      default:
-        this.frame1(g, x, y, friendo)
-        break
-    }
-  }
-
-  frame1(g, x, y, friendo, armAngle = 0.2, squat = 0) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * squat)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-
-    const dumbbellBrush = (_g) => {
-      dumbbell(
-        _g,
-        friendo.element.handCoord.x,
-        friendo.element.handCoord.y,
-        friendo.element.armGirth,
-      )
-    }
-    left(g, x - armOffset.x, y - armOffset.y, dumbbellBrush, armAngle) // left dumbbell
-    right(g, x + armOffset.x, y - armOffset.y, dumbbellBrush, armAngle) // right dumbbell
-
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
+    this.anim = new ACurl(savedState, this.phrasebook)
   }
 }

--- a/src/friendo/state/fitness/dog-cuddle.js
+++ b/src/friendo/state/fitness/dog-cuddle.js
@@ -1,97 +1,14 @@
 import Exercise from './exercise'
-import { left, right } from '../../art/art-util'
-import { ACTIONS, STATS } from '../../constants'
-import { Dog } from '../../art/props/dog'
+import { ACTIONS } from '../../constants'
+import ACuddle from '../../animation/dog-cuddle'
 
 export const ID = ACTIONS.DOG
-
-const DOG_COORDS = [
-  { x: 32, y: 0 },
-  { x: -33, y: 0 },
-  { x: 21, y: -60 },
-  { x: -32, y: -100 },
-  { x: 34, y: -146 },
-]
 
 export default class DogCuddle extends Exercise {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-    this.dogs = [new Dog(), new Dog(), new Dog(), new Dog(), new Dog()]
-  }
 
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 4
-    switch (this.frame) {
-      case 2:
-      case 3:
-        this.frame2(g, x, y, friendo)
-        break
-      case 1:
-      case 0:
-      default:
-        this.frame1(g, x, y, friendo)
-        break
-    }
-    this.drawDogs(g, x, y, friendo, true)
-  }
-
-  coreToDogs(coreLevel) {
-    if (coreLevel > 8) return 5
-    else if (coreLevel > 6) return 4
-    else if (coreLevel > 4) return 3
-    else if (coreLevel > 2) return 2
-    return 1
-  }
-
-  // Draw dogs based on predefined coordinates
-  drawDogs(g, x, y, friendo, lick) {
-    for (let i = 0; i < this.coreToDogs(friendo.getStatStage(STATS.CORE)); i += 1) {
-      this.dogs[i].paint(g, x + DOG_COORDS[i].x, y + DOG_COORDS[i].y, lick)
-    }
-  }
-
-  frame1(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap, bodyOffset } = friendo.element
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.25 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
-  }
-
-  frame2(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.30 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
+    this.anim = new ACuddle(savedState, this.phrasebook)
   }
 }

--- a/src/friendo/state/fitness/feed.js
+++ b/src/friendo/state/fitness/feed.js
@@ -1,8 +1,7 @@
 import Exercise from './exercise'
-import { left, right } from '../../art/art-util'
 import phrasebook from '../../phrases/feed-phrases'
-import { drawGenericFood } from '../../art/props/food'
 import { ACTIONS } from '../../constants'
+import AFeed from '../../animation/feed'
 
 export const ID = ACTIONS.FEED
 
@@ -11,108 +10,6 @@ export default class Feed extends Exercise {
     super(savedState)
     this.id = ID
 
-    this.frame = 0
-
-    this.phrasebook = phrasebook
-    this.words = 'Yum'
-
-    this.frameTotal = 12
-  }
-
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % this.frameTotal
-
-    // state defaults
-    let cT
-    this.mouthIsOpen = true
-    this.isSmiling = false
-
-    switch (this.frame) {
-      case 0:
-      case 4:
-      case 8:
-        cT = this.frame1(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-      case 1:
-      case 5:
-      case 9:
-        this.mouthIsOpen = false
-        cT = this.frame1(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-      case 2:
-      case 6:
-        cT = this.frame2(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-      case 3:
-      case 7:
-        this.mouthIsOpen = false
-        cT = this.frame2(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-
-
-      case 10:
-      case 11:
-        this.isSmiling = true
-        this.mouthIsOpen = false
-        cT = this.frame2(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-      default:
-        cT = this.frame1(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-    }
-  }
-
-  drawFood(g, cT, frame) {
-    drawGenericFood(g, cT.mouth.x, cT.mouth.y + 20, (10 - frame) / 10)
-  }
-
-  frame1(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap, bodyOffset } = friendo.element
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.25 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
-  }
-
-  frame2(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.30 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
+    this.anim = new AFeed(savedState.anim, phrasebook)
   }
 }

--- a/src/friendo/state/fitness/groom.js
+++ b/src/friendo/state/fitness/groom.js
@@ -1,96 +1,14 @@
-import { left, right } from '../../art/art-util'
 import { ACTIONS } from '../../constants'
 import Exercise from './exercise'
-import drawHairbrush from '../../art/props/hairbrush'
+import AGroom from '../../animation/groom'
 
 export const ID = ACTIONS.HAIR
-
-const rotateHairbrush = (g, x, y, angle = 0) => {
-  g.save()
-
-  g.translate(x, y)
-  g.rotate(Math.PI * angle)
-  g.translate(-x, -y)
-
-  drawHairbrush(g, x, y)
-
-  g.restore()
-}
 
 export default class Groom extends Exercise {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-    this.isSmiling = true
-  }
 
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 4
-    let cT
-    /* eslint-disable prefer-destructuring */
-    switch (this.frame) {
-      case 2:
-        cT = this.frame2(g, x, y, friendo)
-        rotateHairbrush(g, x + 26 + (cT.hairXOffset || 0), cT.hairY + 4, -0.25)
-        break
-      case 3:
-        cT = this.frame2(g, x, y, friendo)
-        rotateHairbrush(g, x + 28 + (cT.hairXOffset || 0), cT.hairY + 6, -0.25)
-        break
-      case 1:
-        cT = this.frame1(g, x, y, friendo)
-        rotateHairbrush(g, x + 22 + (cT.hairXOffset || 0), cT.hairY, -0.25)
-        break
-      case 0:
-      default:
-        cT = this.frame1(g, x, y, friendo)
-        rotateHairbrush(g, x + 24 + (cT.hairXOffset || 0), cT.hairY - 4, -0.25)
-        break
-    }
-    /* eslint-enable prefer-destructuring */
-  }
-
-  frame1(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap, bodyOffset } = friendo.element
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.25 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
-  }
-
-  frame2(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.30 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
+    this.anim = new AGroom(savedState, this.phrasebook)
   }
 }

--- a/src/friendo/state/fitness/incubate.js
+++ b/src/friendo/state/fitness/incubate.js
@@ -3,24 +3,19 @@
  * TECHNICALLY this is an exercise but it shares more code with the egg class
  */
 
-import Egg from '../idle/egg'
-import lamp from '../../art/props/lamp'
+import AIncubate from '../../animation/incubate'
 import { ACTIONS } from '../../constants'
+import Exercise from './exercise'
+import { ID as eggID } from '../idle/egg'
 
 export const ID = ACTIONS.EGG
 
-export default class Incubate extends Egg {
+export default class Incubate extends Exercise {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-  }
 
-  draw(g, x, y, friendo) {
-    // draw egg and return tethers, etc.
-    const s = super.draw(g, x, y, friendo)
-
-    lamp(g, x, y)
-
-    return s
+    this.returnTo = eggID
+    this.anim = new AIncubate(savedState, () => [''])
   }
 }

--- a/src/friendo/state/fitness/munch.js
+++ b/src/friendo/state/fitness/munch.js
@@ -1,7 +1,6 @@
 import Exercise from './exercise'
-import { left, right } from '../../art/art-util'
-import { drawGenericFood } from '../../art/props/food'
 import { ACTIONS } from '../../constants'
+import AMunch from '../../animation/munch'
 
 export const ID = ACTIONS.TASTE
 
@@ -10,97 +9,6 @@ export default class Munch extends Exercise {
     super(savedState)
     this.id = ID
 
-    this.frame = 0
-    this.frameTotal = 12
-  }
-
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % this.frameTotal
-
-    // state defaults
-    let cT
-    this.mouthIsOpen = true
-    this.isSmiling = false
-
-    switch (this.frame) {
-      case 0:
-      case 4:
-      case 8:
-        cT = this.frame1(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-      case 1:
-      case 5:
-      case 9:
-        this.mouthIsOpen = false
-        cT = this.frame1(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-      case 2:
-      case 6:
-      case 10:
-        cT = this.frame2(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-      case 3:
-      case 7:
-      case 11:
-        this.mouthIsOpen = false
-        cT = this.frame2(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-      default:
-        cT = this.frame1(g, x, y, friendo)
-        this.drawFood(g, cT, this.frame)
-        break
-    }
-  }
-
-  drawFood(g, cT, frame) {
-    drawGenericFood(g, cT.mouth.x, cT.mouth.y + 20, (10 - frame) / 10)
-  }
-
-  frame1(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap, bodyOffset } = friendo.element
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.25 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
-  }
-
-  frame2(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.1)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.30 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
+    this.anim = new AMunch(savedState, this.phrasebook)
   }
 }

--- a/src/friendo/state/fitness/pet.js
+++ b/src/friendo/state/fitness/pet.js
@@ -1,8 +1,7 @@
 import State from '../state'
-import { left, right } from '../../art/art-util'
-import { drawHandDown as paintHand } from '../../art/props/hand'
 import { ACTIONS } from '../../constants'
 import phrasebook from '../../phrases/idle-phrases'
+import APet from '../../animation/pet'
 
 export const ID = ACTIONS.PET
 
@@ -10,102 +9,7 @@ export default class Petting extends State {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-    this.frame = savedState.frame || 0
-    this.isSmiling = true
 
-    this.phrasebook = phrasebook
-  }
-
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 4
-    let computedTethers
-    switch (this.frame) {
-      case 0:
-        computedTethers = this.frame1(g, x, y, friendo)
-        this.handUp(g, x, computedTethers.hairY)
-        break
-      case 1:
-        computedTethers = this.frame1(g, x, y, friendo)
-        this.handDown(g, x, computedTethers.hairY)
-        break
-      case 2:
-        computedTethers = this.frame2(g, x, y, friendo)
-        this.handUp(g, x, computedTethers.hairY)
-        break
-      case 3:
-        computedTethers = this.frame2(g, x, y, friendo)
-        this.handDown(g, x, computedTethers.hairY)
-        break
-      default:
-        computedTethers = this.frame1(g, x, y, friendo)
-        this.handUp(g, x, computedTethers.hairY)
-        break
-    }
-  }
-
-  frame1(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap, bodyOffset } = friendo.element
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.25 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(
-      g,
-      x,
-      y - bodyOffset,
-      friendo,
-      this.blink,
-      true,
-    )
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
-  }
-
-  frame2(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.30 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(
-      g,
-      x,
-      y - bodyOffset,
-      friendo,
-      this.blink,
-      true,
-    )
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-    return computedTethers
-  }
-
-  handUp(g, x, y) {
-    paintHand(g, x - 4, y - 3)
-  }
-
-  handDown(g, x, y) {
-    paintHand(g, x - 4, y + 1)
+    this.anim = new APet(savedState.old, phrasebook)
   }
 }

--- a/src/friendo/state/fitness/read.js
+++ b/src/friendo/state/fitness/read.js
@@ -1,8 +1,6 @@
-
 import Exercise from './exercise'
-import { left, right } from '../../art/art-util'
 import { ACTIONS } from '../../constants'
-import { drawOpenBook } from '../../art/props/book'
+import ARead from '../../animation/read'
 
 export const ID = ACTIONS.SIGHT
 
@@ -10,60 +8,7 @@ export default class ReadBook extends Exercise {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-    this.glasses = true
-  }
 
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 4
-    switch (this.frame) {
-      case 2:
-      case 3:
-        this.frame1(g, x, y, friendo, 0.40, 0.05)
-        break
-      case 0:
-      case 1:
-      default:
-        this.frame1(g, x, y, friendo)
-        break
-    }
-  }
-
-  frame1(g, x, y, friendo, armAngle = 0.25, squatFactor = 0) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const squatOffset = friendo.element.bodyOffset * squatFactor
-    const bodyOffset = friendo.element.bodyOffset - squatOffset
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y + (-armOffset.y + squatOffset), armBrush, 0.2)// right arm
-
-    // const dumbbellBrush = (_g) => {
-    //   dumbbell(
-    //     _g,
-    //     friendo.element.handCoord.x,
-    //     friendo.element.handCoord.y,
-    //     friendo.element.armGirth,
-    //   )
-    // }
-    // left(g, x - armOffset.x, y - armOffset.y, dumbbellBrush, armAngle) // left dumbbell
-    // right(g, x + armOffset.x, y - armOffset.y, dumbbellBrush, armAngle) // right dumbbell
-
-    left(g, x - armOffset.x, y - armOffset.y, (_g) => {
-      drawOpenBook(_g, friendo.element.handCoord.x, friendo.element.handCoord.y)
-    }, armAngle)
-
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
+    this.anim = new ARead(savedState, this.phrasebook)
   }
 }

--- a/src/friendo/state/fitness/situp.js
+++ b/src/friendo/state/fitness/situp.js
@@ -3,8 +3,8 @@
  */
 
 import Exercise from './exercise'
-import { left, down } from '../../art/art-util'
 import { ACTIONS } from '../../constants'
+import ASitup from '../../animation/situp'
 
 export const ID = ACTIONS.CORE
 
@@ -12,67 +12,6 @@ export default class Situp extends Exercise {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-  }
-
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 4
-    switch (this.frame) {
-      case 2:
-      case 3:
-        down(g, (_g, _x, _y) => {
-          this.frame2(_g, _x, _y, friendo)
-        }, x, y)
-        break
-      case 0:
-      case 1:
-      default:
-        down(g, (_g, _x, _y) => {
-          this.frame1(_g, _x, _y, friendo)
-        }, x, y)
-        break
-    }
-  }
-
-  frame1(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap, bodyOffset } = friendo.element
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset - bodyOffset,
-    }
-    const armAngle = 0.15 // pi radians
-
-    left(g, x - thighGap, y + bodyOffset, legBrush) // left leg
-    left(g, x + thighGap, y + bodyOffset, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-
-    const computedTethers = friendo.element.drawCore(g, x, y, friendo, this.blink)
-    left(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    friendo.element.speak(g, (computedTethers.speech.x + 50), computedTethers.speech.y, friendo)
-  }
-
-  frame2(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap, bodyOffset } = friendo.element
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset - bodyOffset,
-    }
-    const armAngle = 0.25 // pi radians
-
-    left(g, x - thighGap, y + bodyOffset, legBrush) // left leg
-    left(g, x + thighGap, y + bodyOffset, legBrush) // right leg
-    left(g, x - armOffset.x - 6, y - armOffset.y, armBrush, armAngle)// left arm
-
-    const computedTethers = friendo.element.drawCore(g, x - 6, y, friendo, this.blink)
-    left(g, x + (armOffset.x - 6), y - armOffset.y, armBrush, armAngle)// right arm
-    friendo.element.speak(g, (computedTethers.speech.x + 50), computedTethers.speech.y, friendo)
+    this.anim = new ASitup(savedState, this.phrasebook)
   }
 }

--- a/src/friendo/state/fitness/sleep.js
+++ b/src/friendo/state/fitness/sleep.js
@@ -2,10 +2,10 @@
  * Define behavior for a sleeping friendo
  */
 
-import { left, right } from '../../art/art-util'
 import phrasebook from '../../phrases/sleep-phrases'
 import { ACTIONS } from '../../constants'
 import Exercise from './exercise'
+import ASleep from '../../animation/sleep'
 
 export const ID = ACTIONS.SLEEP
 
@@ -14,34 +14,6 @@ export default class Sleep extends Exercise {
     super(savedState)
     this.id = ID
 
-    this.frame = 0
-
-    this.phrasebook = phrasebook
-    this.words = 'zZZ'
-  }
-
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-    this.frame1(g, x, y, friendo)
-  }
-
-  frame1(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.1)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.15 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, true)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
+    this.anim = new ASleep(savedState.anim, phrasebook)
   }
 }

--- a/src/friendo/state/fitness/squat.js
+++ b/src/friendo/state/fitness/squat.js
@@ -3,7 +3,7 @@
  */
 
 import Exercise from './exercise'
-import { left, right } from '../../art/art-util'
+import ASquat from '../../animation/squat'
 import { ACTIONS } from '../../constants'
 
 export const ID = ACTIONS.LEG
@@ -12,43 +12,7 @@ export default class Squat extends Exercise {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-  }
 
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 5
-    switch (this.frame) {
-      case 2:
-      case 3:
-        return this.frame1(g, x, y, friendo, 0.30)
-      case 0:
-      case 1:
-      default:
-        return this.frame1(g, x, y, friendo)
-    }
-  }
-
-  frame1(g, x, y, friendo, squatFactor = 0) {
-    const squatAmount = squatFactor * friendo.element.bodyOffset
-
-    // pre-compute constants for drawing for ease of readability
-    const thighGap = friendo.element.thighGap * (1 + squatFactor)
-    const bodyOffset = friendo.element.bodyOffset - squatAmount
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset - squatAmount,
-    }
-    const armAngle = 0.30 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
+    this.anim = new ASquat(savedState, this.phrasebook)
   }
 }

--- a/src/friendo/state/fitness/surf-web.js
+++ b/src/friendo/state/fitness/surf-web.js
@@ -1,7 +1,6 @@
 import Exercise from './exercise'
-import { left, right } from '../../art/art-util'
 import { ACTIONS } from '../../constants'
-import { drawPhone, PHONE_SCREEN_ON, PHONE_SCREEN_OFF } from '../../art/props/phone'
+import ASurf from '../../animation/surf-web'
 
 export const ID = ACTIONS.MEME
 
@@ -9,48 +8,7 @@ export default class SurfWeb extends Exercise {
   constructor(savedState) {
     super(savedState)
     this.id = ID
-  }
 
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 4
-    switch (this.frame) {
-      case 2:
-      case 3:
-        this.frame1(g, x, y, friendo, 0.30, 0.05, PHONE_SCREEN_ON)
-        break
-      case 0:
-      case 1:
-      default:
-        this.frame1(g, x, y, friendo, 0.20, 0, PHONE_SCREEN_OFF)
-        break
-    }
-  }
-
-  frame1(g, x, y, friendo, armAngle = 0.2, squat = 0, phoneScreen) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * squat)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-
-    const phoneBrush = (_g) => {
-      drawPhone(_g, friendo.element.handCoord.x, friendo.element.handCoord.y, phoneScreen)
-    }
-    left(g, x - armOffset.x, y - armOffset.y, phoneBrush, armAngle) // phone
+    this.anim = new ASurf(savedState, this.phrasebook)
   }
 }

--- a/src/friendo/state/idle/egg.js
+++ b/src/friendo/state/idle/egg.js
@@ -4,7 +4,7 @@
  */
 
 import State from '../state'
-import { STATS } from '../../constants'
+import AEgg from '../../animation/egg'
 
 export const ID = 'state_baby'
 
@@ -13,40 +13,9 @@ export default class Egg extends State {
     if (!savedState) savedState = {}
     super(savedState)
     this.id = ID
-    this.shaking = savedState.shaking || false
-
-    // Left blank to avoid speaking while and egg
-    this.phrasebook = () => ['']
-    this.words = ''
-
     this.returnTo = this.id
-  }
 
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // Shake if not currently shaking and with a probability
-    // based on egg level
-    const rand = Math.floor(Math.random() * 100)
-    const shake =
-      (friendo.getStat(STATS.EGG) < 2 ? 0 : ((friendo.getStat(STATS.EGG) - 1) * 10 >= rand))
-    if (!this.shaking && shake) {
-      this.shaking = true
-    }
-
-    // do a shake
-    if (this.shaking) {
-      this.shaking = false
-      return this.frame2(g, x, y, friendo)
-    }
-    return this.frame1(g, x, y, friendo)
-  }
-
-  frame1(g, x, y, friendo) {
-    friendo.element.drawEgg(g, x, y, friendo)
-  }
-
-  frame2(g, x, y, friendo) {
-    friendo.element.drawEgg(g, x + 2, y, friendo)
+    // phrasebook left blank to avoid speaking while and egg
+    this.anim = new AEgg(savedState.anim, () => [''])
   }
 }

--- a/src/friendo/state/idle/idle.js
+++ b/src/friendo/state/idle/idle.js
@@ -1,6 +1,6 @@
 import State from '../state'
-import { left, right } from '../../art/art-util'
 import phrasebook from '../../phrases/idle-phrases'
+import AIdle from '../../animation/idle'
 
 export const ID = 'state_idle'
 
@@ -9,66 +9,10 @@ export default class Idle extends State {
     super(savedState)
     this.id = ID
 
-    this.frame = 0
-
     this.phrasebook = phrasebook
-    this.words = 'Hi'
+
+    this.anim = new AIdle(savedState.anim, phrasebook)
 
     this.returnTo = this.id
-  }
-
-  draw(g, x, y, friendo) {
-    super.draw(g, x, y, friendo)
-
-    // decide which frame shall be displayed
-    this.frame = (this.frame + 1) % 4
-    switch (this.frame) {
-      case 2:
-      case 3:
-        return this.frame2(g, x, y, friendo)
-      case 0:
-      case 1:
-      default:
-        return this.frame1(g, x, y, friendo)
-    }
-  }
-
-  frame1(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap, bodyOffset } = friendo.element
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.25 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
-  }
-
-  frame2(g, x, y, friendo) {
-    // pre-compute constants for drawing for ease of readability
-    const { thighGap } = friendo.element
-    const bodyOffset = friendo.element.bodyOffset - (friendo.element.bodyOffset * 0.05)
-    const legBrush = friendo.element.legBrush(friendo)
-    const armBrush = friendo.element.armBrush(friendo)
-    const armOffset = {
-      x: friendo.element.armOffset.xOffset,
-      y: friendo.element.legHeight - friendo.element.armOffset.yOffset,
-    }
-    const armAngle = 0.30 // pi radians
-
-    left(g, x - thighGap, y, legBrush) // left leg
-    right(g, x + thighGap, y, legBrush) // right leg
-    left(g, x - armOffset.x, y - armOffset.y, armBrush, armAngle)// left arm
-    right(g, x + armOffset.x, y - armOffset.y, armBrush, armAngle)// right arm
-    const computedTethers = friendo.element.drawCore(g, x, y - bodyOffset, friendo, this.blink)
-    friendo.element.speak(g, x + computedTethers.speech.x, computedTethers.speech.y, friendo)
   }
 }

--- a/src/friendo/state/state.js
+++ b/src/friendo/state/state.js
@@ -1,5 +1,5 @@
-import { BLINK_TIME, SPEAK_TIME, BLINK_CHANCE, SPEAK_CHANCE, TOTAL_EVENT_CHANCE } from '../constants'
 import phrasebook from '../phrases/idle-phrases'
+import FAnimation from '../animation/f-animation'
 
 /**
  *  defines the animation to be done in a given state
@@ -10,19 +10,13 @@ export const ID = 'state_default'
 export default class State {
   constructor(oldState) {
     if (!oldState) oldState = {}
-
     this.id = oldState.id || ID
 
-    this.blinkRate = oldState.blinkRate || BLINK_CHANCE
-    this.speakRate = oldState.speakRate || SPEAK_CHANCE
-    this.blink = oldState.blink || 0
-    this.speak = oldState.speak || 0
     // helps store how much longer to remain in this state
     this.reps = oldState.reps || 0
 
-    // handle case where oldState is JSON rather than an object
-    this.phrasebook = oldState.phrasebook || phrasebook
-    this.words = oldState.words || 'Hi!'
+    // set animation
+    this.anim = new FAnimation(oldState.anim, phrasebook)
 
     // keep track of the state this should default back to
     this.returnTo = this.id
@@ -31,12 +25,8 @@ export default class State {
   toJSON() {
     return {
       id: this.id,
-      blinkRate: this.blinkRate,
-      speakRate: this.speakRate,
-      blink: this.blink,
-      speak: this.speak,
-      words: this.words,
       reps: this.reps,
+      anim: this.anim,
     }
   }
 
@@ -44,32 +34,6 @@ export default class State {
   getReps() { return this.reps }
 
   draw(g, x, y, friendo) {
-    /**
-     *  I know this is terrible practice but sorry yes my draw method has side effects
-     */
-    // handle blink
-    if (this.blink > 0) {
-      this.blink -= 1
-    } else if (Math.random() * TOTAL_EVENT_CHANCE < this.blinkRate) {
-      // not blinking, chance to blink
-      this.blink = BLINK_TIME
-    }
-
-    // handle speech
-    if (this.speak > 0) {
-      this.speak -= 1
-    } else if (Math.random() * TOTAL_EVENT_CHANCE < this.speakRate) {
-      this.speak = SPEAK_TIME
-      this.words = this.pickPhrase(friendo)
-    }
-
-    friendo.element.setColors(g)
-  }
-
-  pickPhrase(friendo) {
-    const list = this.phrasebook(friendo)
-    const selected = Math.floor(Math.random() * list.length)
-    // console.log(`Picked phrase ${selected}`)
-    return list[selected]
+    this.anim.draw(g, x, y, friendo)
   }
 }


### PR DESCRIPTION
## Overview

This set of commits factors animations out of the `state` class so that the two things can be maintained separately, so that state behavior is easier to modify down the line. Not super pleased with the naming conventions I decided on but I started working on this months ago and forget what I was thinking then so I guess this is how it's gonna be.

Resolves #164

