### PR TITLE
:sparkles: Fast-forward the friendo the amount of heartbeats since th…

### DIFF
--- a/src/friendo/friendo.js
+++ b/src/friendo/friendo.js
@@ -47,9 +47,8 @@ import {
 
 export default class Friendo {
   // constructor takes context on which to draw
-  constructor(json) {
+  constructor(fromJSON) {
     // initialize friendo from save file
-    const fromJSON = JSON.parse(json || '{}')
     this._stats = fromJSON.stats || Object.assign({}, DEFAULT_STATS)
     this.state = fromJSON.state ? loadState(fromJSON.state, fromJSON.state.id) : DEFAULT_STATE
     this.name = fromJSON.name || DEFAULT_NAME
@@ -83,7 +82,7 @@ export default class Friendo {
 
   // helper method to create a friendo based on character creation
   static newFriendo(name, owner, element) {
-    return new Friendo(JSON.stringify({ name, owner, element }))
+    return new Friendo({ name, owner, element })
   }
 
   // converts ya boi to a JSON string
@@ -416,5 +415,12 @@ export default class Friendo {
   // handle messages directed at the friendo
   handleAction(action, reps) {
     return this.state.handleAction(this, action, reps)
+  }
+
+  // advances time forward from the last save
+  fastForward(heartbeats) {
+    for (let i = 0; i < heartbeats; i += 1) {
+      this.heartbeat()
+    }
   }
 }

--- a/src/game/game-util.js
+++ b/src/game/game-util.js
@@ -24,7 +24,7 @@ export const saveFriendo = (friendo) => {
 }
 
 // get friendo json from localstorage and decompress it
-export const loadFriendoJSON = () => decompress(localStorage.getItem(STORAGE_TOKEN))
+export const loadFriendoJSON = () => JSON.parse(decompress(localStorage.getItem(STORAGE_TOKEN)))
 
 // hard-reloads the webpage to clear the cache
 export const reload = () => location.reload(true)

--- a/src/game/index.js
+++ b/src/game/index.js
@@ -95,6 +95,11 @@ $(document)
     else {
       // else, initialize game
       friendo = new Friendo(savegame)
+
+      // advance friendo into the future based on how much time has passed
+      const heartbeatsSinceLastSave = (new Date() - new Date(savegame.savedAt)) / HEARTRATE
+      friendo.fastForward(heartbeatsSinceLastSave)
+
       start(friendo)
       hideCreator()
     }


### PR DESCRIPTION
## Overview

This commit fast forwards the Friendo the amount of heartbeats since the last save every time a save is loaded. There's probably a more intelligent way to do this but this works and it shouldn't take thaaaaat long, assuming you didn't last play years ago. This actually makes the Friendo seem a lot more real than I was expecting, which is cool.

This also changes loading savegames to return objects instead of strings, I don't know why that was even like that in the first place.

Resolves #170