### PR TITLE
Move new .gitignore patterns to the top to avoid merge conflicts to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Add new patterns to the top of the file
+# in order to avoid merge conflicts with master
+
+*.friendo
+
 /node_modules
 
 .DS_Store
@@ -16,5 +21,3 @@ yarn-error.log*
 **/.idea/tasks.xml
 
 docs/
-
-*.friendo


### PR DESCRIPTION
## Overview

Does what it says on the tin.