### PR TITLE
Misc. fixes for small screens

### DIFF
--- a/src/game/setup/canvas-listeners.js
+++ b/src/game/setup/canvas-listeners.js
@@ -11,7 +11,7 @@ import $ from 'jquery'
  */
 const resizeCanvas = () => {
   $('#canvas')
-    .width(Math.min(400, Math.floor($(window).width() * 0.95)))
+    .width(Math.min(400, Math.floor($(window).width() * 0.9)))
     .height($('#canvas').width())
 }
 

--- a/src/game/setup/header-listeners.js
+++ b/src/game/setup/header-listeners.js
@@ -76,13 +76,12 @@ const loadFriendo = () => {
 /* eslint-enable no-alert */
 
 export default () => {
-  $('#vernum').html(`[ v${VERSION} ]`).attr('href', `https://github.com/mattdelsordo/friendo/releases/tag/v${VERSION}`)
+  $('#vernum').html(`[v${VERSION}]`).attr('href', `https://github.com/mattdelsordo/friendo/releases/tag/v${VERSION}`)
 
   // show new version alert if necessary
   const showUpdateAlert = cachedVersionMismatch() || daysSinceLastRelease() < 5
   if (showUpdateAlert) {
     $('#version-link').css('visibility', 'visible').addClass('new-version-alert')
-    $('#update-alert').css('display', 'inline')
   }
 
   $('#game-info-icon').mouseenter(() => {

--- a/src/scss/components/canvas.scss
+++ b/src/scss/components/canvas.scss
@@ -8,7 +8,7 @@
     position: absolute;
     top: 0;
     left: 0;
-    z-index: 1;
+    z-index: 0;
 
     button {
         padding: 0.2em;

--- a/src/scss/components/canvas.scss
+++ b/src/scss/components/canvas.scss
@@ -1,5 +1,7 @@
 #canvas {
     background: url('img/bg/bg0.png');
+    background-size: cover !important;
+    background-position: center !important;
 }
 
 #canvas + .dropdown {

--- a/src/scss/components/header.scss
+++ b/src/scss/components/header.scss
@@ -23,6 +23,7 @@ header {
   &-icon {
     margin-top: .35em;
   }
+  white-space: nowrap;
 }
 
 #favicon {
@@ -49,10 +50,6 @@ header {
 
 #version-link, .header-btn {
   visibility: hidden;
-}
-
-#update-alert {
-  display: none;
 }
 
 .new-version-alert {

--- a/src/ui/components/header.pug
+++ b/src/ui/components/header.pug
@@ -2,12 +2,10 @@
 
 // format of header links
 mixin header-btn(txt, emo)
-    a.ml-3.header-btn&attributes(attributes)
+    a.ml-2.header-btn&attributes(attributes)
         | [
-        |
         +emoji(emo)
         span #{txt}
-        |
         | ]
 
 // dialog that displays attributions
@@ -135,8 +133,7 @@ header#header
             +emoji('1f516')(class='ml-4' id='game-info-icon')
             span.ml-2.w-100.d-flex#game-info
                 a#version-link(href="https://github.com/mattdelsordo/friendo/releases" target="_blank")
-                    span#vernum [ v0.0.0 ]
-                    span.ml-1#update-alert NEW!!
+                    span#vernum [v0.0.0]
                 +header-btn('Report a bug', '1f41b')(href="https://github.com/mattdelsordo/friendo/issues" target="_blank")
                 +header-btn('Attributions', '1f4dc')(href="" data-toggle="modal" data-target="#attributions")
             a#settings(href="" data-toggle="modal" data-target="#settings-dialog")


### PR DESCRIPTION
## Overview

1. Modified header elements to be closer together as to not overflow on small screens
2. Fixed canvas background image not resizing appropriately
3. Fixed too-high z-index on background-selector dropdown