### PR TITLE
Drastically shorten hatching time

### DIFF
--- a/src/friendo/balance.js
+++ b/src/friendo/balance.js
@@ -85,7 +85,7 @@ export const LEVEL_MAX = (LVL_CALC_WHITELIST.length * 99) + 1
 
 const EXP_CURVE = Array.from(Array(101), (_, i) => Math.ceil((i ** 1.8) + 8))
 const STEEP_EXP_CURVE = Array.from(Array(101), (_, i) => Math.ceil((i ** 1.9) + 6))
-const EGG_EXP = [0, 240, 180, 180, HATCH_DUR]
+const EGG_EXP = [0, 10, 20, 30, HATCH_DUR]
 
 // returns the exp curve for a given stat
 export const getExpCurve = (stat) => {


### PR DESCRIPTION
## Overview

Eggs were scaled to take over ten minutes to hatch which is way way way too long. People shouldn't have their first experience of the game be immediately leaving the page to wait for something to happen. As an aside, I'm not sure the egg exp numbers were even right in the first place.

Resolves #203 
