### PR TITLE
Avoid service worker 404 on addAll

### DIFF
--- a/build-cache-list.js
+++ b/build-cache-list.js
@@ -29,7 +29,6 @@ const findFilesToCache = (dir, addToList) => {
     const stat = fs.statSync(filepath)
     const relativePath = path.relative(RELATIVE_RES_PATH, filepath)
     if (stat.isDirectory()) {
-      addToList(`/${relativePath}/`)
       findFilesToCache(filepath, addToList)
     } else {
       addToList(`/${relativePath}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friendo",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Friendo: a virtual pal.",
   "main": "index.js",
   "repository": "https://github.com/mattdelsordo/friendo.git",


### PR DESCRIPTION
## Overview

The github pages backend behaves differently to webpack-dev-server
and will 404 instead of returning basic html on requests to directories.
Whether or not the service worker should be handling this this way
should be investigated.